### PR TITLE
Fix white bars on iOS Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="Logan Kulinski — Software engineer, gamer, and horror lover. Creator of cta4j and CTA Smoker Tracker. Connect on GitHub, LinkedIn, and Twitter.">
 
   <!-- Open Graph -->

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,10 @@
   box-sizing: border-box;
 }
 
+html {
+  background: #0a0a1a;
+}
+
 body {
   font-family: 'Inter', sans-serif;
   background: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
@@ -13,7 +17,12 @@ body {
   justify-content: center;
   align-items: flex-start;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 24px 16px;
+  padding-top: max(24px, env(safe-area-inset-top));
+  padding-bottom: max(24px, env(safe-area-inset-bottom));
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-right: max(16px, env(safe-area-inset-right));
 }
 
 .container {


### PR DESCRIPTION
Add viewport-fit=cover, set html background to prevent white safe areas, use env(safe-area-inset-*) for padding, and 100dvh for dynamic viewport height.