### PR TITLE
Fix iOS Safari white bars (v2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
   <meta name="twitter:description" content="Software engineer and Java enthusiast. Creator of cta4j.">
   <meta name="twitter:image" content="https://lbku.net/img/me.JPG">
 
+  <meta name="theme-color" content="#0f0a2e">
+
   <link rel="canonical" href="https://lbku.net">
 
   <title>Logan Kulinski</title>

--- a/styles.css
+++ b/styles.css
@@ -6,12 +6,14 @@
 }
 
 html {
-  background: #0a0a1a;
+  background: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
+  background-attachment: fixed;
+  min-height: 100%;
 }
 
 body {
   font-family: 'Inter', sans-serif;
-  background: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
+  background: transparent;
   color: #e0e0e0;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Move gradient from `body` to `html` with `background-attachment: fixed` — ensures the background covers safe areas and the overscroll bounce area
- Set `body { background: transparent }` so the gradient on `html` shows through
- Add `<meta name="theme-color" content="#0f0a2e">` to darken the browser chrome/status bar area on iOS

## Why the previous fix didn't work
The `html { background: #0a0a1a }` solid color was visible in the safe areas, but when iOS rubber-band scrolls or the gradient didn't perfectly match, white still bled through. Moving the gradient itself to `html` with `fixed` attachment ensures the dark gradient is always the backdrop everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)