### PR TITLE
Fix iOS Safari white bars (v3)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,6 @@
 
 html {
   background: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
-  background-attachment: fixed;
   min-height: 100%;
 }
 


### PR DESCRIPTION
## Root cause
`background-attachment: fixed` is not supported on iOS Safari — it silently fails, causing the `html` background gradient to not render at all. Since `body` was also set to `background: transparent`, there was effectively no background on iOS, showing white everywhere.

## Fix
Remove `background-attachment: fixed`. The gradient on `html` renders correctly without it and still covers safe areas and overscroll zones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)