### PR TITLE
Fix iOS Safari white bars (v4)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,14 +5,17 @@
   box-sizing: border-box;
 }
 
-html {
+html,
+body {
   background: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
+}
+
+html {
   min-height: 100%;
 }
 
 body {
   font-family: 'Inter', sans-serif;
-  background: transparent;
   color: #e0e0e0;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Root cause
`body` was set to `background: transparent`, leaving it relying solely on `html` for the background. iOS Safari doesn't always propagate `html` background into safe areas correctly in this setup.

## Fix
Apply the gradient to both `html` and `body` — the same pattern that works in `cta-smokers-front-end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)