### PR TITLE
Fix iOS Safari white bars (v5)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,8 @@
 
 html,
 body {
-  background: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
+  background-color: #0f0a2e;
+  background-image: linear-gradient(160deg, #0f0a2e, #0a0a1a, #0a1525);
 }
 
 html {


### PR DESCRIPTION
## Root cause
iOS 26 Safari dropped support for the `theme-color` meta tag and now uses the `body`'s **`background-color`** to tint the top/bottom bars. The `background` shorthand (`background: linear-gradient(...)`) resets `background-color` to `transparent`, which Safari treats as white for bar tinting.

## Fix
Split `background` into `background-color` and `background-image` on both `html` and `body`:
- `background-color: #0f0a2e` → explicit dark color iOS 26 uses for bar tinting
- `background-image: linear-gradient(...)` → gradient still renders visually

## References
- [iOS26 Safari theme-color/tab-tinting with fixed position elements – Ben Frain](https://benfrain.com/ios26-safari-theme-color-tab-tinting-with-fixed-position-elements/)
- [Safari iOS 26 viewport bug – Apple Community](https://discussions.apple.com/thread/256138682)

🤖 Generated with [Claude Code](https://claude.com/claude-code)